### PR TITLE
🗃️ Remove version field from pipeline table

### DIFF
--- a/lndb_schema_core/__init__.py
+++ b/lndb_schema_core/__init__.py
@@ -15,7 +15,7 @@ All models:
    dtransform_in
    dtransform_out
    jupynb
-   pipeline
+   pipeline_run
    usage
    version_yvzi
 
@@ -39,7 +39,7 @@ from ._core import (  # noqa
     dtransform_in,
     dtransform_out,
     jupynb,
-    pipeline,
+    pipeline_run,
     usage,
     usage_type,
     user,

--- a/lndb_schema_core/_core.py
+++ b/lndb_schema_core/_core.py
@@ -68,7 +68,9 @@ class dtransform(SQLModel, table=True):  # type: ignore
     id: str = Field(default_factory=id_dtransform, primary_key=True)
     jupynb_id: Union[str, None] = None
     jupynb_v: Union[str, None] = None
-    pipeline_id: Union[str, None] = Field(default=None, foreign_key="pipeline.id")
+    pipeline_run_id: Union[str, None] = Field(
+        default=None, foreign_key="pipeline_run.id"
+    )
 
 
 class dtransform_in(SQLModel, table=True):  # type: ignore
@@ -112,8 +114,8 @@ class jupynb(SQLModel, table=True):  # type: ignore
     time_updated: datetime = Field(default_factory=utcnow, nullable=False)
 
 
-class pipeline(SQLModel, table=True):  # type: ignore
-    """Pipelines."""
+class pipeline_run(SQLModel, table=True):  # type: ignore
+    """Pipeline runs."""
 
     id: str = Field(default=None, primary_key=True)
 


### PR DESCRIPTION
See title.
- Pipeline schema left with a simple id PK for the moment. 
- Composite FK removed from dtransform.