### PR TITLE
✨ Add components of global hub schema

### DIFF
--- a/lnschema_core/_core.py
+++ b/lnschema_core/_core.py
@@ -1,7 +1,7 @@
 from datetime import datetime as datetime
 from typing import Optional
 
-from sqlmodel import Field, ForeignKeyConstraint, SQLModel
+from sqlmodel import Field, ForeignKeyConstraint, PrimaryKeyConstraint, SQLModel
 
 from . import id as idg
 from ._timestamps import CreatedAt, UpdatedAt
@@ -42,6 +42,39 @@ class storage(SQLModel, table=True):  # type: ignore
     """Cloud storage region if applicable."""
     created_at: datetime = CreatedAt
     updated_at: Optional[datetime] = UpdatedAt
+
+
+class instance(SQLModel, table=True):  # type: ignore
+    """Instances."""
+
+    id: str = Field(default=None, primary_key=True)
+    name: Optional[str]
+    storage_id: str = Field(foreign_key=storage.id)
+    dbconfig: str
+    cache_dir: str
+    sqlite_file: str
+    sqlite_file_local: str
+    db: str
+    created_at: datetime = CreatedAt
+    updated_at: Optional[datetime] = UpdatedAt
+
+
+class user_instance(SQLModel, table=True):  # type: ignore
+    """Relationships between users and instances."""
+
+    __table_args__ = (PrimaryKeyConstraint("user_id", "instance_id"),)
+    user_id: str = Field(foreign_key=user.id, index=True)
+    instance_id: str = Field(foreign_key=instance.id, index=True)
+    reated_at: datetime = CreatedAt
+
+
+class dtranform_instance(SQLModel, table=True):  # type: ignore
+    """Relationships between users and instances."""
+
+    __table_args__ = (PrimaryKeyConstraint("dtranform_id", "instance_id"),)
+    dtranform_id: str = Field(foreign_key="dtransform.id", index=True)
+    instance_id: str = Field(foreign_key=instance.id, index=True)
+    reated_at: datetime = CreatedAt
 
 
 class dobject(SQLModel, table=True):  # type: ignore


### PR DESCRIPTION
We want to make converge both schemas for mainly 2 reasons:
- Enabling to use almost the same schema definition and migrations code for both
- Enabling to have almost the same way to query data for globale and private hub 

Here we try to achieve this by adding some stuffs to the schema (lnschema_core), that would enable it to handle multiple instances into the same database.  

Doing it not necessarily mean that we will enable users to use the same database for different instances, this is just a way to make private hub a special case of the global one.