### PR TITLE
👷 Reformat to 176 char line length

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,7 @@ repos:
     rev: 22.6.0
     hooks:
       - id: black-jupyter
+        args: [--line-length=150]
   - repo: https://github.com/pycqa/flake8
     rev: 4.0.1
     hooks:
@@ -23,7 +24,7 @@ repos:
           - flake8-typing-imports==1.10.0
         language_version: python3
         args:
-          - --max-line-length=88
+          - --max-line-length=150
           - --ignore=E203,BLK100
         exclude: |
           (?x)(

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
     rev: 22.6.0
     hooks:
       - id: black-jupyter
-        args: [--line-length=150]
+        args: [--line-length=176]
   - repo: https://github.com/pycqa/flake8
     rev: 4.0.1
     hooks:
@@ -24,7 +24,7 @@ repos:
           - flake8-typing-imports==1.10.0
         language_version: python3
         args:
-          - --max-line-length=150
+          - --max-line-length=176
           - --ignore=E203,BLK100
         exclude: |
           (?x)(

--- a/lnschema_core/_core.py
+++ b/lnschema_core/_core.py
@@ -153,9 +153,7 @@ class DObject(SQLModel, table=True):  # type: ignore
     It's `None` if the storage format doesn't have a canonical extension.
     """
 
-    size: Optional[int] = Field(
-        default=None, sa_column=sa.Column(sa.BigInteger(), index=True)
-    )
+    size: Optional[int] = Field(default=None, sa_column=sa.Column(sa.BigInteger(), index=True))
     """Size in bytes.
 
     Examples: 1KB is 1e3 bytes, 1MB is 1e6, 1GB is 1e9, 1TB is 1e12 etc.
@@ -165,9 +163,7 @@ class DObject(SQLModel, table=True):  # type: ignore
 
     # We need the fully module-qualified path below, as there might be more
     # schema modules with an ORM called "Run"
-    source: "lnschema_core._core.Run" = Relationship(  # type: ignore  # noqa
-        back_populates="outputs"
-    )
+    source: "lnschema_core._core.Run" = Relationship(back_populates="outputs")  # type: ignore  # noqa
     """Link to :class:`~lnschema_core.Run` that generated the `dobject`."""
     run_id: str = Field(foreign_key="core.run.id", index=True)
     """The source run id."""
@@ -328,9 +324,7 @@ class Run(SQLModel, table=True):  # type: ignore
     """Link to :class:`~lnschema_core.Notebook`."""
     outputs: List["DObject"] = Relationship(back_populates="source")
     """Output data :class:`~lnschema_core.DObject`."""
-    inputs: List["DObject"] = Relationship(
-        back_populates="targets", sa_relationship_kwargs=dict(secondary=RunIn.__table__)
-    )
+    inputs: List["DObject"] = Relationship(back_populates="targets", sa_relationship_kwargs=dict(secondary=RunIn.__table__))
     """Input data :class:`~lnschema_core.DObject`."""
     created_by: str = CreatedBy
     """Auto-populated link to :class:`~lnschema_core.User`."""

--- a/lnschema_core/_users.py
+++ b/lnschema_core/_users.py
@@ -7,6 +7,4 @@ def current_user_id():
     return settings.user.id
 
 
-CreatedBy = Field(
-    default_factory=current_user_id, foreign_key="core.user.id", index=True
-)
+CreatedBy = Field(default_factory=current_user_id, foreign_key="core.user.id", index=True)

--- a/lnschema_core/dev/sqlmodel.py
+++ b/lnschema_core/dev/sqlmodel.py
@@ -30,11 +30,7 @@ SCHEMA_NAME = None
 
 def __repr_args__(self) -> Sequence[Tuple[Optional[str], Any]]:
     # sort like fields
-    return [
-        (k, self.__dict__[k])
-        for k in self.__fields__
-        if (not k.startswith("_sa_") and k in self.__dict__ and self.__dict__[k] is not None)  # noqa  # noqa
-    ]
+    return [(k, self.__dict__[k]) for k in self.__fields__ if (not k.startswith("_sa_") and k in self.__dict__ and self.__dict__[k] is not None)]  # noqa  # noqa
 
 
 sqm.SQLModel.__repr_args__ = __repr_args__

--- a/lnschema_core/dev/sqlmodel.py
+++ b/lnschema_core/dev/sqlmodel.py
@@ -33,11 +33,7 @@ def __repr_args__(self) -> Sequence[Tuple[Optional[str], Any]]:
     return [
         (k, self.__dict__[k])
         for k in self.__fields__
-        if (
-            not k.startswith("_sa_")
-            and k in self.__dict__  # noqa
-            and self.__dict__[k] is not None  # noqa
-        )
+        if (not k.startswith("_sa_") and k in self.__dict__ and self.__dict__[k] is not None)  # noqa  # noqa
     ]
 
 

--- a/lnschema_core/migrations/versions/2022-07-21-0560ee3d73dc-jupynb.py
+++ b/lnschema_core/migrations/versions/2022-07-21-0560ee3d73dc-jupynb.py
@@ -81,11 +81,7 @@ def upgrade() -> None:
         ),
         sa.PrimaryKeyConstraint("id"),
     )
-    op.execute(
-        "insert into track_do_ (id, type, user_id, jupynb_id, time, dobject_id) "
-        "select id, type, user_id, interface_id, time, dobject_id "
-        "from track_do"
-    )
+    op.execute("insert into track_do_ (id, type, user_id, jupynb_id, time, dobject_id) select id, type, user_id, interface_id, time, dobject_id from track_do")
     op.execute("update track_do_ SET jupynb_v = '1'")
     op.execute("update track_do_ SET dobject_v = '1'")
     op.drop_table("track_do")

--- a/lnschema_core/migrations/versions/2022-07-21-0560ee3d73dc-jupynb.py
+++ b/lnschema_core/migrations/versions/2022-07-21-0560ee3d73dc-jupynb.py
@@ -51,9 +51,7 @@ def upgrade() -> None:
         sa.Column("jupynb_v", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
         sa.Column("time_created", sa.DateTime(), nullable=False),
         sa.Column("time_updated", sa.DateTime(), nullable=False),
-        sa.ForeignKeyConstraint(
-            ["jupynb_id", "jupynb_v"], ["jupynb.id", "jupynb.v"], name="dobject_jupynb"
-        ),
+        sa.ForeignKeyConstraint(["jupynb_id", "jupynb_v"], ["jupynb.id", "jupynb.v"], name="dobject_jupynb"),
         sa.PrimaryKeyConstraint("id", "v"),
     )
     op.execute("insert into dobject_ select * from dobject")
@@ -76,9 +74,7 @@ def upgrade() -> None:
             ["dobject.id", "dobject.v"],
             name="track_do_dobject",
         ),
-        sa.ForeignKeyConstraint(
-            ["jupynb_id", "jupynb_v"], ["jupynb.id", "jupynb.v"], name="track_do_jupynb"
-        ),
+        sa.ForeignKeyConstraint(["jupynb_id", "jupynb_v"], ["jupynb.id", "jupynb.v"], name="track_do_jupynb"),
         sa.ForeignKeyConstraint(
             ["user_id"],
             ["user.id"],

--- a/lnschema_core/migrations/versions/2022-08-08-8c78543d1c5b-v0_3_0.py
+++ b/lnschema_core/migrations/versions/2022-08-08-8c78543d1c5b-v0_3_0.py
@@ -119,11 +119,7 @@ def upgrade() -> None:
     )
     op.drop_table("dobject")
     op.rename_table("dobject_", "dobject")
-    op.execute(
-        "update dobject set dsource_id = (select id from dtransform where"
-        " (dtransform.jupynb_id, dtransform.jupynb_v) = (dobject.jupynb_id,"
-        " dobject.jupynb_v))"
-    )
+    op.execute("update dobject set dsource_id = (select id from dtransform where (dtransform.jupynb_id, dtransform.jupynb_v) = (dobject.jupynb_id, dobject.jupynb_v))")
     # now we don't need these two columns anymore on dobject
     op.drop_column("dobject", "jupynb_v")
     op.drop_column("dobject", "jupynb_id")
@@ -151,9 +147,7 @@ def upgrade() -> None:
         ),
         sa.PrimaryKeyConstraint("id"),
     )
-    op.execute(
-        "insert into usage (id, type, user_id, time, dobject_id, dobject_v) select id, type, user_id, time, dobject_id, dobject_v from track_do"
-    )
+    op.execute("insert into usage (id, type, user_id, time, dobject_id, dobject_v) select id, type, user_id, time, dobject_id, dobject_v from track_do")
     op.drop_table("track_do")
 
     # jupynb table no longer has type

--- a/lnschema_core/migrations/versions/2022-08-08-8c78543d1c5b-v0_3_0.py
+++ b/lnschema_core/migrations/versions/2022-08-08-8c78543d1c5b-v0_3_0.py
@@ -37,9 +37,7 @@ def upgrade() -> None:
         ),
         sa.PrimaryKeyConstraint("v"),
     )
-    op.execute(
-        "insert into version_yvzi select id, user_id, time_created from schema_version"
-    )
+    op.execute("insert into version_yvzi select id, user_id, time_created from schema_version")
     op.drop_table("schema_version")
 
     # New table where we need to insert a link to dobject and to jupynb
@@ -94,9 +92,7 @@ def upgrade() -> None:
         ),
         sa.PrimaryKeyConstraint("dtransform_id", "dobject_id", "dobject_v"),
     )
-    op.execute(
-        "insert into dtransform (id, jupynb_id, jupynb_v) select id, id, v from jupynb"
-    )
+    op.execute("insert into dtransform (id, jupynb_id, jupynb_v) select id, id, v from jupynb")
 
     # Add the dsouce_id column and insert data
     op.create_table(
@@ -133,10 +129,7 @@ def upgrade() -> None:
     op.drop_column("dobject", "jupynb_id")
 
     # Populate dtransform_out
-    op.execute(
-        "insert into dtransform_out (dtransform_id, dobject_id, dobject_v) select"
-        " dsource_id, id, v from dobject"
-    )
+    op.execute("insert into dtransform_out (dtransform_id, dobject_id, dobject_v) select dsource_id, id, v from dobject")
 
     # This is a rename from track_do, so we got to insert all data from track_do
     op.create_table(
@@ -159,8 +152,7 @@ def upgrade() -> None:
         sa.PrimaryKeyConstraint("id"),
     )
     op.execute(
-        "insert into usage (id, type, user_id, time, dobject_id, dobject_v) select id,"
-        " type, user_id, time, dobject_id, dobject_v from track_do"
+        "insert into usage (id, type, user_id, time, dobject_id, dobject_v) select id, type, user_id, time, dobject_id, dobject_v from track_do"
     )
     op.drop_table("track_do")
 

--- a/lnschema_core/migrations/versions/2022-08-22-01fcb82dafd4-v0_4_0.py
+++ b/lnschema_core/migrations/versions/2022-08-22-01fcb82dafd4-v0_4_0.py
@@ -43,18 +43,11 @@ def upgrade() -> None:
         ),
         sa.PrimaryKeyConstraint("id"),
     )
-    op.execute(
-        "insert into dtransform_tmp (id, jupynb_id, jupynb_v) select id, jupynb_id,"
-        " jupynb_v from dtransform"
-    )
+    op.execute("insert into dtransform_tmp (id, jupynb_id, jupynb_v) select id, jupynb_id, jupynb_v from dtransform")
     op.drop_table("dtransform")
     op.rename_table("dtransform_tmp", "dtransform")
-    op.create_index(
-        op.f("ix_dtransform_jupynb_id"), "dtransform", ["jupynb_id"], unique=False
-    )
-    op.create_index(
-        op.f("ix_dtransform_jupynb_v"), "dtransform", ["jupynb_v"], unique=False
-    )
+    op.create_index(op.f("ix_dtransform_jupynb_id"), "dtransform", ["jupynb_id"], unique=False)
+    op.create_index(op.f("ix_dtransform_jupynb_v"), "dtransform", ["jupynb_v"], unique=False)
     op.create_index(
         op.f("ix_dtransform_pipeline_run_id"),
         "dtransform",
@@ -70,9 +63,7 @@ def upgrade() -> None:
         "dobject_tmp",
         sa.Column("id", sqlmodel.sql.sqltypes.AutoString(), nullable=True),
         sa.Column("v", sqlmodel.sql.sqltypes.AutoString(), nullable=True),
-        sa.Column(
-            "name", sqlmodel.sql.sqltypes.AutoString(), nullable=True, index=True
-        ),
+        sa.Column("name", sqlmodel.sql.sqltypes.AutoString(), nullable=True, index=True),
         sa.Column(
             "file_suffix",
             sqlmodel.sql.sqltypes.AutoString(),
@@ -103,12 +94,8 @@ def upgrade() -> None:
 
     # Create indexes on jupynb
     op.create_index(op.f("ix_jupynb_name"), "jupynb", ["name"], unique=False)
-    op.create_index(
-        op.f("ix_jupynb_time_created"), "jupynb", ["time_created"], unique=False
-    )
-    op.create_index(
-        op.f("ix_jupynb_time_updated"), "jupynb", ["time_updated"], unique=False
-    )
+    op.create_index(op.f("ix_jupynb_time_created"), "jupynb", ["time_created"], unique=False)
+    op.create_index(op.f("ix_jupynb_time_updated"), "jupynb", ["time_updated"], unique=False)
     op.create_index(op.f("ix_jupynb_user_id"), "jupynb", ["user_id"], unique=False)
 
     # Create indexes on usage

--- a/lnschema_core/migrations/versions/2022-08-26-3badf20f18c8-v0_5_0.py
+++ b/lnschema_core/migrations/versions/2022-08-26-3badf20f18c8-v0_5_0.py
@@ -25,12 +25,8 @@ def upgrade() -> None:
         sa.PrimaryKeyConstraint("id", "v"),
     )
     op.create_index(op.f("ix_pipeline_name"), "pipeline", ["name"], unique=False)
-    op.create_index(
-        op.f("ix_pipeline_reference"), "pipeline", ["reference"], unique=False
-    )
-    op.add_column(
-        "dobject", sa.Column("storage_id", sqlmodel.sql.sqltypes.AutoString())
-    )
+    op.create_index(op.f("ix_pipeline_reference"), "pipeline", ["reference"], unique=False)
+    op.add_column("dobject", sa.Column("storage_id", sqlmodel.sql.sqltypes.AutoString()))
     op.alter_column("dobject", "dtransform_id", existing_type=sa.VARCHAR())
     op.drop_index("ix_dobject_tmp_dtransform_id", table_name="dobject")
     op.drop_index("ix_dobject_tmp_file_suffix", table_name="dobject")
@@ -38,22 +34,12 @@ def upgrade() -> None:
     op.drop_index("ix_dobject_tmp_storage_root", table_name="dobject")
     op.drop_index("ix_dobject_tmp_time_created", table_name="dobject")
     op.drop_index("ix_dobject_tmp_time_updated", table_name="dobject")
-    op.create_index(
-        op.f("ix_dobject_dtransform_id"), "dobject", ["dtransform_id"], unique=False
-    )
-    op.create_index(
-        op.f("ix_dobject_file_suffix"), "dobject", ["file_suffix"], unique=False
-    )
+    op.create_index(op.f("ix_dobject_dtransform_id"), "dobject", ["dtransform_id"], unique=False)
+    op.create_index(op.f("ix_dobject_file_suffix"), "dobject", ["file_suffix"], unique=False)
     op.create_index(op.f("ix_dobject_name"), "dobject", ["name"], unique=False)
-    op.create_index(
-        op.f("ix_dobject_storage_id"), "dobject", ["storage_id"], unique=False
-    )
-    op.create_index(
-        op.f("ix_dobject_time_created"), "dobject", ["time_created"], unique=False
-    )
-    op.create_index(
-        op.f("ix_dobject_time_updated"), "dobject", ["time_updated"], unique=False
-    )
+    op.create_index(op.f("ix_dobject_storage_id"), "dobject", ["storage_id"], unique=False)
+    op.create_index(op.f("ix_dobject_time_created"), "dobject", ["time_created"], unique=False)
+    op.create_index(op.f("ix_dobject_time_updated"), "dobject", ["time_updated"], unique=False)
     op.add_column(
         "pipeline_run",
         sa.Column("pipeline_id", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
@@ -66,25 +52,17 @@ def upgrade() -> None:
         "pipeline_run",
         sa.Column("name", sqlmodel.sql.sqltypes.AutoString(), nullable=True),
     )
-    op.create_index(
-        op.f("ix_pipeline_run_name"), "pipeline_run", ["name"], unique=False
-    )
+    op.create_index(op.f("ix_pipeline_run_name"), "pipeline_run", ["name"], unique=False)
     op.create_index(
         op.f("ix_pipeline_run_pipeline_id"),
         "pipeline_run",
         ["pipeline_id"],
         unique=False,
     )
-    op.create_index(
-        op.f("ix_pipeline_run_pipeline_v"), "pipeline_run", ["pipeline_v"], unique=False
-    )
+    op.create_index(op.f("ix_pipeline_run_pipeline_v"), "pipeline_run", ["pipeline_v"], unique=False)
     with op.batch_alter_table("pipeline") as batch_op:
-        batch_op.create_foreign_key(
-            "pipeline_run", "pipeline", ["pipeline_id", "pipeline_v"], ["id", "v"]
-        )
-    op.add_column(
-        "storage", sa.Column("id", sqlmodel.sql.sqltypes.AutoString(), nullable=True)
-    )
+        batch_op.create_foreign_key("pipeline_run", "pipeline", ["pipeline_id", "pipeline_v"], ["id", "v"])
+    op.add_column("storage", sa.Column("id", sqlmodel.sql.sqltypes.AutoString(), nullable=True))
     op.create_index(op.f("ix_storage_root"), "storage", ["root"], unique=False)
     op.alter_column("user", "handle", existing_type=sa.VARCHAR())
     with op.batch_alter_table("user") as batch_op:

--- a/lnschema_core/migrations/versions/2022-08-29-d1b3e5da6391-v0_5_1.py
+++ b/lnschema_core/migrations/versions/2022-08-29-d1b3e5da6391-v0_5_1.py
@@ -20,13 +20,9 @@ def upgrade() -> None:
     with op.batch_alter_table("dobject") as batch_op:
         batch_op.drop_column("storage_root")
     op.add_column("pipeline", sa.Column("time_created", sa.DateTime(), nullable=False))
-    op.add_column(
-        "pipeline_run", sa.Column("time_created", sa.DateTime(), nullable=False)
-    )
+    op.add_column("pipeline_run", sa.Column("time_created", sa.DateTime(), nullable=False))
     with op.batch_alter_table("pipeline") as batch_op:
-        batch_op.create_foreign_key(
-            "pipeline_run", "pipeline", ["pipeline_id", "pipeline_v"], ["id", "v"]
-        )
+        batch_op.create_foreign_key("pipeline_run", "pipeline", ["pipeline_id", "pipeline_v"], ["id", "v"])
 
 
 def downgrade() -> None:

--- a/lnschema_core/migrations/versions/2022-09-18-3b60b87450c0-v0_7_0.py
+++ b/lnschema_core/migrations/versions/2022-09-18-3b60b87450c0-v0_7_0.py
@@ -28,21 +28,13 @@ def upgrade() -> None:
         batch_op.add_column(sa.Column("updated_at", sa.DateTime(), nullable=True))
         batch_op.alter_column("id", existing_type=sa.VARCHAR(), nullable=False)
         batch_op.alter_column("v", existing_type=sa.VARCHAR(), nullable=False)
-        batch_op.alter_column(
-            "dtransform_id", existing_type=sa.VARCHAR(), nullable=False
-        )
+        batch_op.alter_column("dtransform_id", existing_type=sa.VARCHAR(), nullable=False)
         batch_op.alter_column("storage_id", existing_type=sa.VARCHAR(), nullable=False)
         batch_op.drop_index("ix_dobject_time_created")
         batch_op.drop_index("ix_dobject_time_updated")
-        batch_op.create_index(
-            batch_op.f("ix_dobject_created_at"), ["created_at"], unique=False
-        )
-        batch_op.create_index(
-            batch_op.f("ix_dobject_updated_at"), ["updated_at"], unique=False
-        )
-        batch_op.create_foreign_key(
-            "fk_object_storage_id_storage", "storage", ["storage_id"], ["id"]
-        )
+        batch_op.create_index(batch_op.f("ix_dobject_created_at"), ["created_at"], unique=False)
+        batch_op.create_index(batch_op.f("ix_dobject_updated_at"), ["updated_at"], unique=False)
+        batch_op.create_foreign_key("fk_object_storage_id_storage", "storage", ["storage_id"], ["id"])
         batch_op.drop_column("time_created")
         batch_op.drop_column("time_updated")
 
@@ -63,12 +55,8 @@ def upgrade() -> None:
         batch_op.alter_column("v", existing_type=sa.VARCHAR(), nullable=False)
         batch_op.drop_index("ix_jupynb_time_created")
         batch_op.drop_index("ix_jupynb_time_updated")
-        batch_op.create_index(
-            batch_op.f("ix_jupynb_created_at"), ["created_at"], unique=False
-        )
-        batch_op.create_index(
-            batch_op.f("ix_jupynb_updated_at"), ["updated_at"], unique=False
-        )
+        batch_op.create_index(batch_op.f("ix_jupynb_created_at"), ["created_at"], unique=False)
+        batch_op.create_index(batch_op.f("ix_jupynb_updated_at"), ["updated_at"], unique=False)
         batch_op.drop_column("time_created")
         batch_op.drop_column("time_updated")
 
@@ -84,12 +72,8 @@ def upgrade() -> None:
         batch_op.add_column(sa.Column("updated_at", sa.DateTime(), nullable=True))
         batch_op.alter_column("id", existing_type=sa.VARCHAR(), nullable=False)
         batch_op.alter_column("v", existing_type=sa.VARCHAR(), nullable=False)
-        batch_op.create_index(
-            batch_op.f("ix_pipeline_created_at"), ["created_at"], unique=False
-        )
-        batch_op.create_index(
-            batch_op.f("ix_pipeline_updated_at"), ["updated_at"], unique=False
-        )
+        batch_op.create_index(batch_op.f("ix_pipeline_created_at"), ["created_at"], unique=False)
+        batch_op.create_index(batch_op.f("ix_pipeline_updated_at"), ["updated_at"], unique=False)
         batch_op.drop_column("time_created")
 
     with op.batch_alter_table("pipeline_run", schema=None) as batch_op:
@@ -102,12 +86,8 @@ def upgrade() -> None:
             )
         )
         batch_op.alter_column("id", existing_type=sa.VARCHAR(), nullable=False)
-        batch_op.create_index(
-            batch_op.f("ix_pipeline_run_created_at"), ["created_at"], unique=False
-        )
-        batch_op.create_foreign_key(
-            "pipeline", "pipeline", ["pipeline_id", "pipeline_v"], ["id", "v"]
-        )
+        batch_op.create_index(batch_op.f("ix_pipeline_run_created_at"), ["created_at"], unique=False)
+        batch_op.create_foreign_key("pipeline", "pipeline", ["pipeline_id", "pipeline_v"], ["id", "v"])
         batch_op.drop_column("time_created")
 
     with op.batch_alter_table("storage", schema=None) as batch_op:
@@ -121,12 +101,8 @@ def upgrade() -> None:
         )
         batch_op.add_column(sa.Column("updated_at", sa.DateTime(), nullable=True))
         batch_op.alter_column("id", existing_type=sa.VARCHAR(), nullable=False)
-        batch_op.create_index(
-            batch_op.f("ix_storage_created_at"), ["created_at"], unique=False
-        )
-        batch_op.create_index(
-            batch_op.f("ix_storage_updated_at"), ["updated_at"], unique=False
-        )
+        batch_op.create_index(batch_op.f("ix_storage_created_at"), ["created_at"], unique=False)
+        batch_op.create_index(batch_op.f("ix_storage_updated_at"), ["updated_at"], unique=False)
         batch_op.drop_column("time_created")
         batch_op.drop_column("time_updated")
 
@@ -145,12 +121,8 @@ def upgrade() -> None:
         batch_op.add_column(sa.Column("updated_at", sa.DateTime(), nullable=True))
         batch_op.alter_column("id", existing_type=sa.VARCHAR(), nullable=False)
         batch_op.alter_column("handle", existing_type=sa.VARCHAR(), nullable=False)
-        batch_op.create_index(
-            batch_op.f("ix_user_created_at"), ["created_at"], unique=False
-        )
-        batch_op.create_index(
-            batch_op.f("ix_user_updated_at"), ["updated_at"], unique=False
-        )
+        batch_op.create_index(batch_op.f("ix_user_created_at"), ["created_at"], unique=False)
+        batch_op.create_index(batch_op.f("ix_user_updated_at"), ["updated_at"], unique=False)
         batch_op.drop_column("time_created")
         batch_op.drop_column("time_updated")
 
@@ -164,9 +136,7 @@ def upgrade() -> None:
             )
         )
         batch_op.alter_column("v", existing_type=sa.VARCHAR(), nullable=False)
-        batch_op.create_index(
-            batch_op.f("ix_version_yvzi_created_at"), ["created_at"], unique=False
-        )
+        batch_op.create_index(batch_op.f("ix_version_yvzi_created_at"), ["created_at"], unique=False)
         batch_op.drop_column("time_created")
 
 

--- a/lnschema_core/migrations/versions/2022-10-07-0c819d33ca9b-v0_10_0.py
+++ b/lnschema_core/migrations/versions/2022-10-07-0c819d33ca9b-v0_10_0.py
@@ -21,30 +21,22 @@ def upgrade() -> None:
     op.execute("update jupynb set created_by = user_id")
     with op.batch_alter_table("jupynb", schema=None) as batch_op:
         batch_op.drop_index("ix_jupynb_user_id")
-        batch_op.create_index(
-            batch_op.f("ix_jupynb_created_by"), ["created_by"], unique=False
-        )
+        batch_op.create_index(batch_op.f("ix_jupynb_created_by"), ["created_by"], unique=False)
         batch_op.create_foreign_key("fk_created_by", "user", ["created_by"], ["id"])
         batch_op.drop_column("user_id")
 
     with op.batch_alter_table("pipeline", schema=None) as batch_op:
         batch_op.add_column(sa.Column("created_by", sqlmodel.sql.sqltypes.AutoString()))
-        batch_op.create_index(
-            batch_op.f("ix_pipeline_created_by"), ["created_by"], unique=False
-        )
+        batch_op.create_index(batch_op.f("ix_pipeline_created_by"), ["created_by"], unique=False)
         batch_op.create_foreign_key("fk_created_by", "user", ["created_by"], ["id"])
 
     with op.batch_alter_table("pipeline_run", schema=None) as batch_op:
         batch_op.add_column(sa.Column("created_by", sqlmodel.sql.sqltypes.AutoString()))
-        batch_op.create_index(
-            batch_op.f("ix_pipeline_run_created_by"), ["created_by"], unique=False
-        )
+        batch_op.create_index(batch_op.f("ix_pipeline_run_created_by"), ["created_by"], unique=False)
         batch_op.create_foreign_key("fk_created_by", "user", ["created_by"], ["id"])
 
     with op.batch_alter_table("version_yvzi", schema=None) as batch_op:
-        batch_op.create_index(
-            batch_op.f("ix_version_yvzi_user_id"), ["user_id"], unique=False
-        )
+        batch_op.create_index(batch_op.f("ix_version_yvzi_user_id"), ["user_id"], unique=False)
 
 
 def downgrade() -> None:

--- a/lnschema_core/migrations/versions/2022-10-11-2ddcb037e3ea-v0_12_0.py
+++ b/lnschema_core/migrations/versions/2022-10-11-2ddcb037e3ea-v0_12_0.py
@@ -18,12 +18,8 @@ depends_on = None
 
 def upgrade() -> None:
     with op.batch_alter_table("dobject", schema=None) as batch_op:
-        batch_op.add_column(
-            sa.Column("checksum", sqlmodel.sql.sqltypes.AutoString(), nullable=True)
-        )
-        batch_op.create_index(
-            batch_op.f("ix_dobject_checksum"), ["checksum"], unique=False
-        )
+        batch_op.add_column(sa.Column("checksum", sqlmodel.sql.sqltypes.AutoString(), nullable=True))
+        batch_op.create_index(batch_op.f("ix_dobject_checksum"), ["checksum"], unique=False)
 
 
 def downgrade() -> None:

--- a/lnschema_core/migrations/versions/2022-10-19-cf5913791674-v0_14_0.py
+++ b/lnschema_core/migrations/versions/2022-10-19-cf5913791674-v0_14_0.py
@@ -36,16 +36,10 @@ def upgrade() -> None:
         sa.PrimaryKeyConstraint("id"),
     )
     with op.batch_alter_table("dset", schema=None) as batch_op:
-        batch_op.create_index(
-            batch_op.f("ix_dset_created_at"), ["created_at"], unique=False
-        )
-        batch_op.create_index(
-            batch_op.f("ix_dset_created_by"), ["created_by"], unique=False
-        )
+        batch_op.create_index(batch_op.f("ix_dset_created_at"), ["created_at"], unique=False)
+        batch_op.create_index(batch_op.f("ix_dset_created_by"), ["created_by"], unique=False)
         batch_op.create_index(batch_op.f("ix_dset_name"), ["name"], unique=False)
-        batch_op.create_index(
-            batch_op.f("ix_dset_updated_at"), ["updated_at"], unique=False
-        )
+        batch_op.create_index(batch_op.f("ix_dset_updated_at"), ["updated_at"], unique=False)
 
     op.create_table(
         "project",
@@ -66,16 +60,10 @@ def upgrade() -> None:
         sa.PrimaryKeyConstraint("id"),
     )
     with op.batch_alter_table("project", schema=None) as batch_op:
-        batch_op.create_index(
-            batch_op.f("ix_project_created_at"), ["created_at"], unique=False
-        )
-        batch_op.create_index(
-            batch_op.f("ix_project_created_by"), ["created_by"], unique=False
-        )
+        batch_op.create_index(batch_op.f("ix_project_created_at"), ["created_at"], unique=False)
+        batch_op.create_index(batch_op.f("ix_project_created_by"), ["created_by"], unique=False)
         batch_op.create_index(batch_op.f("ix_project_name"), ["name"], unique=False)
-        batch_op.create_index(
-            batch_op.f("ix_project_updated_at"), ["updated_at"], unique=False
-        )
+        batch_op.create_index(batch_op.f("ix_project_updated_at"), ["updated_at"], unique=False)
 
     op.create_table(
         "project_dset",

--- a/lnschema_core/migrations/versions/2022-10-31-98da12fc80a8-v0_15_0.py
+++ b/lnschema_core/migrations/versions/2022-10-31-98da12fc80a8-v0_15_0.py
@@ -20,24 +20,16 @@ def upgrade() -> None:
         op.rename_table(old_table_name="dtransform", new_table_name="core.dtransform")
         op.rename_table(old_table_name="storage", new_table_name="core.storage")
         op.rename_table(old_table_name="user", new_table_name="core.user")
-        op.rename_table(
-            old_table_name="dtransform_in", new_table_name="core.dtransform_in"
-        )
+        op.rename_table(old_table_name="dtransform_in", new_table_name="core.dtransform_in")
         op.rename_table(old_table_name="dobject", new_table_name="core.dobject")
         op.rename_table(old_table_name="usage", new_table_name="core.usage")
         op.rename_table(old_table_name="jupynb", new_table_name="core.jupynb")
         op.rename_table(old_table_name="pipeline", new_table_name="core.pipeline")
-        op.rename_table(
-            old_table_name="pipeline_run", new_table_name="core.pipeline_run"
-        )
+        op.rename_table(old_table_name="pipeline_run", new_table_name="core.pipeline_run")
         op.rename_table(old_table_name="dset", new_table_name="core.dset")
         op.rename_table(old_table_name="project", new_table_name="core.project")
-        op.rename_table(
-            old_table_name="project_dset", new_table_name="core.project_dset"
-        )
-        op.rename_table(
-            old_table_name="dset_dobject", new_table_name="core.dset_dobject"
-        )
+        op.rename_table(old_table_name="project_dset", new_table_name="core.project_dset")
+        op.rename_table(old_table_name="dset_dobject", new_table_name="core.dset_dobject")
     else:
         op.execute("alter table public.dtransform set schema core")
         op.execute("alter table public.storage set schema core")

--- a/lnschema_core/migrations/versions/2022-11-10-4ee426b656bb-v0_16_0.py
+++ b/lnschema_core/migrations/versions/2022-11-10-4ee426b656bb-v0_16_0.py
@@ -18,9 +18,7 @@ depends_on = None
 
 def upgrade_sqlite() -> None:
     op.rename_table("core.pipeline_run", "core.run")
-    op.alter_column(
-        "core.dtransform", column_name="pipeline_run_id", new_column_name="run_id"
-    )
+    op.alter_column("core.dtransform", column_name="pipeline_run_id", new_column_name="run_id")
 
     # clean up names
     with op.batch_alter_table("core.dobject", schema=None) as batch_op:
@@ -32,60 +30,32 @@ def upgrade_sqlite() -> None:
         batch_op.drop_index("ix_dobject_storage_id")
         batch_op.drop_index("ix_dobject_suffix")
         batch_op.drop_index("ix_dobject_updated_at")
-        batch_op.create_index(
-            batch_op.f("ix_core.dobject_checksum"), ["checksum"], unique=False
-        )
-        batch_op.create_index(
-            batch_op.f("ix_core.dobject_created_at"), ["created_at"], unique=False
-        )
-        batch_op.create_index(
-            batch_op.f("ix_core.dobject_dtransform_id"), ["dtransform_id"], unique=False
-        )
-        batch_op.create_index(
-            batch_op.f("ix_core.dobject_name"), ["name"], unique=False
-        )
-        batch_op.create_index(
-            batch_op.f("ix_core.dobject_size"), ["size"], unique=False
-        )
-        batch_op.create_index(
-            batch_op.f("ix_core.dobject_storage_id"), ["storage_id"], unique=False
-        )
-        batch_op.create_index(
-            batch_op.f("ix_core.dobject_suffix"), ["suffix"], unique=False
-        )
-        batch_op.create_index(
-            batch_op.f("ix_core.dobject_updated_at"), ["updated_at"], unique=False
-        )
+        batch_op.create_index(batch_op.f("ix_core.dobject_checksum"), ["checksum"], unique=False)
+        batch_op.create_index(batch_op.f("ix_core.dobject_created_at"), ["created_at"], unique=False)
+        batch_op.create_index(batch_op.f("ix_core.dobject_dtransform_id"), ["dtransform_id"], unique=False)
+        batch_op.create_index(batch_op.f("ix_core.dobject_name"), ["name"], unique=False)
+        batch_op.create_index(batch_op.f("ix_core.dobject_size"), ["size"], unique=False)
+        batch_op.create_index(batch_op.f("ix_core.dobject_storage_id"), ["storage_id"], unique=False)
+        batch_op.create_index(batch_op.f("ix_core.dobject_suffix"), ["suffix"], unique=False)
+        batch_op.create_index(batch_op.f("ix_core.dobject_updated_at"), ["updated_at"], unique=False)
 
     with op.batch_alter_table("core.dset", schema=None) as batch_op:
         batch_op.drop_index("ix_dset_created_at")
         batch_op.drop_index("ix_dset_created_by")
         batch_op.drop_index("ix_dset_name")
         batch_op.drop_index("ix_dset_updated_at")
-        batch_op.create_index(
-            batch_op.f("ix_core.dset_created_at"), ["created_at"], unique=False
-        )
-        batch_op.create_index(
-            batch_op.f("ix_core.dset_created_by"), ["created_by"], unique=False
-        )
+        batch_op.create_index(batch_op.f("ix_core.dset_created_at"), ["created_at"], unique=False)
+        batch_op.create_index(batch_op.f("ix_core.dset_created_by"), ["created_by"], unique=False)
         batch_op.create_index(batch_op.f("ix_core.dset_name"), ["name"], unique=False)
-        batch_op.create_index(
-            batch_op.f("ix_core.dset_updated_at"), ["updated_at"], unique=False
-        )
+        batch_op.create_index(batch_op.f("ix_core.dset_updated_at"), ["updated_at"], unique=False)
 
     with op.batch_alter_table("core.dtransform", schema=None) as batch_op:
         batch_op.drop_index("ix_dtransform_jupynb_id")
         batch_op.drop_index("ix_dtransform_jupynb_v")
         batch_op.drop_index("ix_dtransform_pipeline_run_id")
-        batch_op.create_index(
-            batch_op.f("ix_core.dtransform_jupynb_id"), ["jupynb_id"], unique=False
-        )
-        batch_op.create_index(
-            batch_op.f("ix_core.dtransform_jupynb_v"), ["jupynb_v"], unique=False
-        )
-        batch_op.create_index(
-            batch_op.f("ix_core.dtransform_run_id"), ["run_id"], unique=False
-        )
+        batch_op.create_index(batch_op.f("ix_core.dtransform_jupynb_id"), ["jupynb_id"], unique=False)
+        batch_op.create_index(batch_op.f("ix_core.dtransform_jupynb_v"), ["jupynb_v"], unique=False)
+        batch_op.create_index(batch_op.f("ix_core.dtransform_run_id"), ["run_id"], unique=False)
         # the following line should be built in already into the alter_column in l. 21
         # batch_op.create_foreign_key(
         #    batch_op.f('fk_core.dtransform_run_id_run'), 'core.run', ['run_id'], ['id']
@@ -96,16 +66,10 @@ def upgrade_sqlite() -> None:
         batch_op.drop_index("ix_jupynb_created_by")
         batch_op.drop_index("ix_jupynb_name")
         batch_op.drop_index("ix_jupynb_updated_at")
-        batch_op.create_index(
-            batch_op.f("ix_core.jupynb_created_at"), ["created_at"], unique=False
-        )
-        batch_op.create_index(
-            batch_op.f("ix_core.jupynb_created_by"), ["created_by"], unique=False
-        )
+        batch_op.create_index(batch_op.f("ix_core.jupynb_created_at"), ["created_at"], unique=False)
+        batch_op.create_index(batch_op.f("ix_core.jupynb_created_by"), ["created_by"], unique=False)
         batch_op.create_index(batch_op.f("ix_core.jupynb_name"), ["name"], unique=False)
-        batch_op.create_index(
-            batch_op.f("ix_core.jupynb_updated_at"), ["updated_at"], unique=False
-        )
+        batch_op.create_index(batch_op.f("ix_core.jupynb_updated_at"), ["updated_at"], unique=False)
 
     with op.batch_alter_table("core.pipeline", schema=None) as batch_op:
         batch_op.drop_index("ix_pipeline_created_at")
@@ -113,39 +77,21 @@ def upgrade_sqlite() -> None:
         batch_op.drop_index("ix_pipeline_name")
         batch_op.drop_index("ix_pipeline_reference")
         batch_op.drop_index("ix_pipeline_updated_at")
-        batch_op.create_index(
-            batch_op.f("ix_core.pipeline_created_at"), ["created_at"], unique=False
-        )
-        batch_op.create_index(
-            batch_op.f("ix_core.pipeline_created_by"), ["created_by"], unique=False
-        )
-        batch_op.create_index(
-            batch_op.f("ix_core.pipeline_name"), ["name"], unique=False
-        )
-        batch_op.create_index(
-            batch_op.f("ix_core.pipeline_reference"), ["reference"], unique=False
-        )
-        batch_op.create_index(
-            batch_op.f("ix_core.pipeline_updated_at"), ["updated_at"], unique=False
-        )
+        batch_op.create_index(batch_op.f("ix_core.pipeline_created_at"), ["created_at"], unique=False)
+        batch_op.create_index(batch_op.f("ix_core.pipeline_created_by"), ["created_by"], unique=False)
+        batch_op.create_index(batch_op.f("ix_core.pipeline_name"), ["name"], unique=False)
+        batch_op.create_index(batch_op.f("ix_core.pipeline_reference"), ["reference"], unique=False)
+        batch_op.create_index(batch_op.f("ix_core.pipeline_updated_at"), ["updated_at"], unique=False)
 
     with op.batch_alter_table("core.project", schema=None) as batch_op:
         batch_op.drop_index("ix_project_created_at")
         batch_op.drop_index("ix_project_created_by")
         batch_op.drop_index("ix_project_name")
         batch_op.drop_index("ix_project_updated_at")
-        batch_op.create_index(
-            batch_op.f("ix_core.project_created_at"), ["created_at"], unique=False
-        )
-        batch_op.create_index(
-            batch_op.f("ix_core.project_created_by"), ["created_by"], unique=False
-        )
-        batch_op.create_index(
-            batch_op.f("ix_core.project_name"), ["name"], unique=False
-        )
-        batch_op.create_index(
-            batch_op.f("ix_core.project_updated_at"), ["updated_at"], unique=False
-        )
+        batch_op.create_index(batch_op.f("ix_core.project_created_at"), ["created_at"], unique=False)
+        batch_op.create_index(batch_op.f("ix_core.project_created_by"), ["created_by"], unique=False)
+        batch_op.create_index(batch_op.f("ix_core.project_name"), ["name"], unique=False)
+        batch_op.create_index(batch_op.f("ix_core.project_updated_at"), ["updated_at"], unique=False)
 
     with op.batch_alter_table("core.run", schema=None) as batch_op:
         batch_op.drop_index("ix_pipeline_run_created_at")
@@ -153,47 +99,29 @@ def upgrade_sqlite() -> None:
         batch_op.drop_index("ix_pipeline_run_name")
         batch_op.drop_index("ix_pipeline_run_pipeline_id")
         batch_op.drop_index("ix_pipeline_run_pipeline_v")
-        batch_op.create_index(
-            batch_op.f("ix_core.run_created_at"), ["created_at"], unique=False
-        )
-        batch_op.create_index(
-            batch_op.f("ix_core.run_created_by"), ["created_by"], unique=False
-        )
+        batch_op.create_index(batch_op.f("ix_core.run_created_at"), ["created_at"], unique=False)
+        batch_op.create_index(batch_op.f("ix_core.run_created_by"), ["created_by"], unique=False)
         batch_op.create_index(batch_op.f("ix_core.run_name"), ["name"], unique=False)
-        batch_op.create_index(
-            batch_op.f("ix_core.run_pipeline_id"), ["pipeline_id"], unique=False
-        )
-        batch_op.create_index(
-            batch_op.f("ix_core.run_pipeline_v"), ["pipeline_v"], unique=False
-        )
+        batch_op.create_index(batch_op.f("ix_core.run_pipeline_id"), ["pipeline_id"], unique=False)
+        batch_op.create_index(batch_op.f("ix_core.run_pipeline_v"), ["pipeline_v"], unique=False)
 
     with op.batch_alter_table("core.storage", schema=None) as batch_op:
         batch_op.drop_index("ix_storage_created_at")
         batch_op.drop_index("ix_storage_root")
         batch_op.drop_index("ix_storage_updated_at")
-        batch_op.create_index(
-            batch_op.f("ix_core.storage_created_at"), ["created_at"], unique=False
-        )
-        batch_op.create_index(
-            batch_op.f("ix_core.storage_root"), ["root"], unique=False
-        )
-        batch_op.create_index(
-            batch_op.f("ix_core.storage_updated_at"), ["updated_at"], unique=False
-        )
+        batch_op.create_index(batch_op.f("ix_core.storage_created_at"), ["created_at"], unique=False)
+        batch_op.create_index(batch_op.f("ix_core.storage_root"), ["root"], unique=False)
+        batch_op.create_index(batch_op.f("ix_core.storage_updated_at"), ["updated_at"], unique=False)
 
     with op.batch_alter_table("core.usage", schema=None) as batch_op:
         batch_op.drop_index("ix_usage_dobject_id")
         batch_op.drop_index("ix_usage_time")
         batch_op.drop_index("ix_usage_type")
         batch_op.drop_index("ix_usage_user_id")
-        batch_op.create_index(
-            batch_op.f("ix_core.usage_dobject_id"), ["dobject_id"], unique=False
-        )
+        batch_op.create_index(batch_op.f("ix_core.usage_dobject_id"), ["dobject_id"], unique=False)
         batch_op.create_index(batch_op.f("ix_core.usage_time"), ["time"], unique=False)
         batch_op.create_index(batch_op.f("ix_core.usage_type"), ["type"], unique=False)
-        batch_op.create_index(
-            batch_op.f("ix_core.usage_user_id"), ["user_id"], unique=False
-        )
+        batch_op.create_index(batch_op.f("ix_core.usage_user_id"), ["user_id"], unique=False)
 
     with op.batch_alter_table("core.user", schema=None) as batch_op:
         batch_op.drop_index("ix_user_created_at")
@@ -201,17 +129,11 @@ def upgrade_sqlite() -> None:
         batch_op.drop_index("ix_user_handle")
         batch_op.drop_index("ix_user_name")
         batch_op.drop_index("ix_user_updated_at")
-        batch_op.create_index(
-            batch_op.f("ix_core.user_created_at"), ["created_at"], unique=False
-        )
+        batch_op.create_index(batch_op.f("ix_core.user_created_at"), ["created_at"], unique=False)
         batch_op.create_index(batch_op.f("ix_core.user_email"), ["email"], unique=True)
-        batch_op.create_index(
-            batch_op.f("ix_core.user_handle"), ["handle"], unique=True
-        )
+        batch_op.create_index(batch_op.f("ix_core.user_handle"), ["handle"], unique=True)
         batch_op.create_index(batch_op.f("ix_core.user_name"), ["name"], unique=False)
-        batch_op.create_index(
-            batch_op.f("ix_core.user_updated_at"), ["updated_at"], unique=False
-        )
+        batch_op.create_index(batch_op.f("ix_core.user_updated_at"), ["updated_at"], unique=False)
 
 
 def upgrade_postgres():

--- a/lnschema_core/migrations/versions/2022-11-11-66bfd6cf2e2d-v0_17_0.py
+++ b/lnschema_core/migrations/versions/2022-11-11-66bfd6cf2e2d-v0_17_0.py
@@ -27,21 +27,11 @@ def upgrade() -> None:
         prefix, schema = "", "core"
 
     with op.batch_alter_table(f"{prefix}dtransform", schema=schema) as batch_op:
-        batch_op.add_column(
-            sa.Column("name", sqlmodel.sql.sqltypes.AutoString(), nullable=True)
-        )
-        batch_op.add_column(
-            sa.Column("pipeline_id", sqlmodel.sql.sqltypes.AutoString(), nullable=True)
-        )
-        batch_op.add_column(
-            sa.Column("pipeline_v", sqlmodel.sql.sqltypes.AutoString(), nullable=True)
-        )
-        batch_op.create_index(
-            batch_op.f("ix_core.dtransform_pipeline_id"), ["pipeline_id"], unique=False
-        )
-        batch_op.create_index(
-            batch_op.f("ix_core.dtransform_pipeline_v"), ["pipeline_v"], unique=False
-        )
+        batch_op.add_column(sa.Column("name", sqlmodel.sql.sqltypes.AutoString(), nullable=True))
+        batch_op.add_column(sa.Column("pipeline_id", sqlmodel.sql.sqltypes.AutoString(), nullable=True))
+        batch_op.add_column(sa.Column("pipeline_v", sqlmodel.sql.sqltypes.AutoString(), nullable=True))
+        batch_op.create_index(batch_op.f("ix_core.dtransform_pipeline_id"), ["pipeline_id"], unique=False)
+        batch_op.create_index(batch_op.f("ix_core.dtransform_pipeline_v"), ["pipeline_v"], unique=False)
         batch_op.add_column(
             sa.Column(
                 "created_by",
@@ -58,15 +48,9 @@ def upgrade() -> None:
                 nullable=False,
             )
         )
-        batch_op.create_index(
-            batch_op.f("ix_core.dtransform_created_at"), ["created_at"], unique=False
-        )
-        batch_op.create_index(
-            batch_op.f("ix_core.dtransform_created_by"), ["created_by"], unique=False
-        )
-        batch_op.create_index(
-            batch_op.f("ix_core.dtransform_name"), ["name"], unique=False
-        )
+        batch_op.create_index(batch_op.f("ix_core.dtransform_created_at"), ["created_at"], unique=False)
+        batch_op.create_index(batch_op.f("ix_core.dtransform_created_by"), ["created_by"], unique=False)
+        batch_op.create_index(batch_op.f("ix_core.dtransform_name"), ["name"], unique=False)
         if sqlite:
             batch_op.create_foreign_key(
                 batch_op.f("fk_core.dtransform_pipeline_id_pipeline"),
@@ -131,9 +115,7 @@ def upgrade() -> None:
     try:
         op.drop_index("ix_core.dtransform_run_id")
         op.drop_constraint("bfx_run_id_fkey", "run", schema="bfx")
-        op.drop_constraint(
-            "dtransform_pipeline_run_id_fkey", "dtransform", schema="core"
-        )
+        op.drop_constraint("dtransform_pipeline_run_id_fkey", "dtransform", schema="core")
     except Exception:
         pass
     op.drop_column(f"{prefix}dtransform", "run_id", schema=schema)

--- a/lnschema_core/migrations/versions/2022-11-28-4b4005b7841c-v0_21_1.py
+++ b/lnschema_core/migrations/versions/2022-11-28-4b4005b7841c-v0_21_1.py
@@ -47,19 +47,13 @@ def upgrade() -> None:
             sa.PrimaryKeyConstraint("id", name=op.f("pk_core.features")),
         )
         with op.batch_alter_table("core.features", schema=None) as batch_op:
-            batch_op.create_index(
-                batch_op.f("ix_core.features_created_at"), ["created_at"], unique=False
-            )
-            batch_op.create_index(
-                batch_op.f("ix_core.features_created_by"), ["created_by"], unique=False
-            )
+            batch_op.create_index(batch_op.f("ix_core.features_created_at"), ["created_at"], unique=False)
+            batch_op.create_index(batch_op.f("ix_core.features_created_by"), ["created_by"], unique=False)
 
         op.create_table(
             "core.dobject_features",
             sa.Column("dobject_id", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
-            sa.Column(
-                "features_id", sqlmodel.sql.sqltypes.AutoString(), nullable=False
-            ),
+            sa.Column("features_id", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
             sa.ForeignKeyConstraint(
                 ["dobject_id"],
                 ["core.dobject.id"],
@@ -70,9 +64,7 @@ def upgrade() -> None:
                 ["core.features.id"],
                 name=op.f("fk_core.dobject_features_features_id_features"),
             ),
-            sa.PrimaryKeyConstraint(
-                "dobject_id", "features_id", name=op.f("pk_core.dobject_features")
-            ),
+            sa.PrimaryKeyConstraint("dobject_id", "features_id", name=op.f("pk_core.dobject_features")),
         )
         with op.batch_alter_table("core.storage", schema=None) as batch_op:
             batch_op.drop_index("ix_core.storage_created_at")
@@ -94,25 +86,13 @@ def upgrade() -> None:
         batch_op.drop_index("ix_core.dtransform_name")
         batch_op.drop_index("ix_core.dtransform_pipeline_id")
         batch_op.drop_index("ix_core.dtransform_pipeline_v")
-        batch_op.create_index(
-            batch_op.f("ix_core.run_created_at"), ["created_at"], unique=False
-        )
-        batch_op.create_index(
-            batch_op.f("ix_core.run_created_by"), ["created_by"], unique=False
-        )
-        batch_op.create_index(
-            batch_op.f("ix_core.run_jupynb_id"), ["jupynb_id"], unique=False
-        )
-        batch_op.create_index(
-            batch_op.f("ix_core.run_jupynb_v"), ["jupynb_v"], unique=False
-        )
+        batch_op.create_index(batch_op.f("ix_core.run_created_at"), ["created_at"], unique=False)
+        batch_op.create_index(batch_op.f("ix_core.run_created_by"), ["created_by"], unique=False)
+        batch_op.create_index(batch_op.f("ix_core.run_jupynb_id"), ["jupynb_id"], unique=False)
+        batch_op.create_index(batch_op.f("ix_core.run_jupynb_v"), ["jupynb_v"], unique=False)
         batch_op.create_index(batch_op.f("ix_core.run_name"), ["name"], unique=False)
-        batch_op.create_index(
-            batch_op.f("ix_core.run_pipeline_id"), ["pipeline_id"], unique=False
-        )
-        batch_op.create_index(
-            batch_op.f("ix_core.run_pipeline_v"), ["pipeline_v"], unique=False
-        )
+        batch_op.create_index(batch_op.f("ix_core.run_pipeline_id"), ["pipeline_id"], unique=False)
+        batch_op.create_index(batch_op.f("ix_core.run_pipeline_v"), ["pipeline_v"], unique=False)
         batch_op.create_foreign_key(
             batch_op.f("fk_core.run_pipeline_id_pipeline"),
             "core.pipeline",

--- a/lnschema_core/migrations/versions/2022-12-07-db1df7b2aaad-v0_22_0.py
+++ b/lnschema_core/migrations/versions/2022-12-07-db1df7b2aaad-v0_22_0.py
@@ -28,18 +28,10 @@ def upgrade() -> None:
     op.rename_table(f"{prefix}jupynb", f"{prefix}notebook", schema=schema)
 
     with op.batch_alter_table(f"{prefix}notebook", schema=schema) as batch_op:
-        batch_op.create_index(
-            batch_op.f("ix_core.notebook_created_at"), ["created_at"], unique=False
-        )
-        batch_op.create_index(
-            batch_op.f("ix_core.notebook_created_by"), ["created_by"], unique=False
-        )
-        batch_op.create_index(
-            batch_op.f("ix_core.notebook_name"), ["name"], unique=False
-        )
-        batch_op.create_index(
-            batch_op.f("ix_core.notebook_updated_at"), ["updated_at"], unique=False
-        )
+        batch_op.create_index(batch_op.f("ix_core.notebook_created_at"), ["created_at"], unique=False)
+        batch_op.create_index(batch_op.f("ix_core.notebook_created_by"), ["created_by"], unique=False)
+        batch_op.create_index(batch_op.f("ix_core.notebook_name"), ["name"], unique=False)
+        batch_op.create_index(batch_op.f("ix_core.notebook_updated_at"), ["updated_at"], unique=False)
         batch_op.drop_index("ix_core.jupynb_created_at")
         batch_op.drop_index("ix_core.jupynb_created_by")
         batch_op.drop_index("ix_core.jupynb_name")
@@ -60,12 +52,8 @@ def upgrade() -> None:
     with op.batch_alter_table(f"{prefix}run", schema=schema) as batch_op:
         batch_op.drop_index("ix_core.run_jupynb_id")
         batch_op.drop_index("ix_core.run_jupynb_v")
-        batch_op.create_index(
-            batch_op.f("ix_core.run_notebook_id"), ["notebook_id"], unique=False
-        )
-        batch_op.create_index(
-            batch_op.f("ix_core.run_notebook_v"), ["notebook_v"], unique=False
-        )
+        batch_op.create_index(batch_op.f("ix_core.run_notebook_id"), ["notebook_id"], unique=False)
+        batch_op.create_index(batch_op.f("ix_core.run_notebook_v"), ["notebook_v"], unique=False)
         batch_op.create_foreign_key(
             batch_op.f("fk_core.run_notebook_id_notebook"),
             "core.notebook",


### PR DESCRIPTION
Migration scripts and model definitions are significantly more readable when they are subject to a double line length, preventing any undesired line wrapping.

The black standard is 88, hence double is 176.