### PR TITLE
✨ Delete storage in File.delete if called outside lamindb

### DIFF
--- a/lnschema_core/models.py
+++ b/lnschema_core/models.py
@@ -664,7 +664,7 @@ class File(BaseORM):
 
     def delete(self, *args, **kwargs) -> None:
         exec_module = executor_name()
-        if exec_module != "lamindb":
+        if exec_module not in ("lamindb", "lnschema_core"):
             from lamindb.dev.storage import delete_storage
 
             storage_key = storage_key_from_file(self)

--- a/lnschema_core/models.py
+++ b/lnschema_core/models.py
@@ -664,7 +664,6 @@ class File(BaseORM):
 
     def delete(self, *args, **kwargs) -> None:
         exec_module = executor_name()
-        print(exec_module)
         if exec_module != "lamindb":
             from lamindb.dev.storage import delete_storage
 


### PR DESCRIPTION
This allows to use `File.delete` as before (i.e. without deleting storage) inside lamindb but calling outside will also delete storage objects.
@falexwolf do you think it is a reasonable approach?