### PR TITLE
Add registries docstring

### DIFF
--- a/lnschema_core/models.py
+++ b/lnschema_core/models.py
@@ -1118,6 +1118,7 @@ class Feature(Registry, CanValidate):
         unit: `Optional[str] = None` Unit of measure, ideally SI (`"m"`, `"s"`, `"kg"`, etc.) or `"normalized"` etc.
         description: `Optional[str] = None` A description.
         synonyms: `Optional[str] = None` Bar-separated synonyms.
+        registries: `Optional[str] = None` Bar-separated Registries that provide values for labels.
 
     .. note::
 


### PR DESCRIPTION
I was looking at https://github.com/laminlabs/lamindb/blob/main/lamindb/dev/datasets/_core.py#L331 and couldn't find a docstring for `registries`. Is there a reason why we omit it?