### PR TITLE
Fix typo

### DIFF
--- a/lnschema_core/models.py
+++ b/lnschema_core/models.py
@@ -1210,7 +1210,7 @@ class Feature(Registry, CanValidate):
 
     @classmethod
     def from_df(cls, df: "pd.DataFrame", field: Optional[FieldAttr] = None) -> "RecordsList":
-        """Create Feature records for columns."""
+        """Create Feature records for columns"""
         pass
 
     def save(self, *args, **kwargs) -> None:

--- a/lnschema_core/models.py
+++ b/lnschema_core/models.py
@@ -1209,7 +1209,7 @@ class Feature(Registry, CanValidate):
 
     @classmethod
     def from_df(cls, df: "pd.DataFrame") -> "RecordsList":
-        """Create Feature records for columns."""
+        """Create Feature records for columns"""
         pass
 
     def save(self, *args, **kwargs) -> None:


### PR DESCRIPTION
![image](https://github.com/laminlabs/lnschema-core/assets/21954664/99f9b3cc-9d73-48c1-a24c-9f7948124d42)

I'm a bit confused why this isn't an issue for the docstring of `save` which has the same structure
