### PR TITLE
🐛 Simplify __repr__ and test for __repr__

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,8 +18,8 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.11"]
     timeout-minutes: 15
 
     steps:
@@ -22,8 +22,6 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          cache: "pip"
-          cache-dependency-path: ".github/workflows/build.yml" # See dependencies below
       - name: cache pre-commit
         uses: actions/cache@v3
         with:

--- a/lnschema_core/models.py
+++ b/lnschema_core/models.py
@@ -621,11 +621,11 @@ class RecordMeta(ModelBase):
             )
 
         non_external_schema_fields_formatted = [
-            f"    .{field.name.replace('_links', '')}: {_get_related_field_type(field)}\n"
+            f"    .{field.name}: {_get_related_field_type(field)}\n"
             for field in non_external_schema_fields
         ]
         external_schema_fields_formatted = [
-            f"    .{field.name.replace('_links', '')}: {_get_related_field_type(field)}\n"
+            f"    .{field.name}: {_get_related_field_type(field)}\n"
             for field in external_schema_fields
         ]
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,5 +1,5 @@
 import nox
-from laminci.nox import login_testuser1, run, run_pre_commit, run_pytest
+from laminci.nox import run, run_pre_commit, run_pytest
 
 nox.options.default_venv_backend = "none"
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -11,10 +11,10 @@ def lint(session: nox.Session) -> None:
 
 @nox.session
 def test(session: nox.Session) -> None:
-    login_testuser1(session)
     run(session, "pip install -e .[dev]")
     run(
         session,
         "pip install lamindb_setup@git+https://github.com/laminlabs/lamindb-setup",
     )
+    login_testuser1(session)
     run_pytest(session, coverage=False)

--- a/noxfile.py
+++ b/noxfile.py
@@ -11,6 +11,7 @@ def lint(session: nox.Session) -> None:
 
 @nox.session
 def test(session: nox.Session) -> None:
+    login_testuser1()
     run(session, "pip install -e .[dev]")
     run(
         session,

--- a/noxfile.py
+++ b/noxfile.py
@@ -11,9 +11,9 @@ def lint(session: nox.Session) -> None:
 
 @nox.session
 def test(session: nox.Session) -> None:
-    run(session, "pip install -e .[dev]")
+    run(session, "uv pip install --system -e .[dev]")
     run(
         session,
-        "pip install lamindb_setup@git+https://github.com/laminlabs/lamindb-setup",
+        "uv pip install lamindb@git+https://github.com/laminlabs/lamindb",
     )
     run_pytest(session, coverage=False)

--- a/noxfile.py
+++ b/noxfile.py
@@ -11,7 +11,7 @@ def lint(session: nox.Session) -> None:
 
 @nox.session
 def test(session: nox.Session) -> None:
-    login_testuser1()
+    login_testuser1(session)
     run(session, "pip install -e .[dev]")
     run(
         session,

--- a/noxfile.py
+++ b/noxfile.py
@@ -14,6 +14,6 @@ def test(session: nox.Session) -> None:
     run(session, "uv pip install --system -e .[dev]")
     run(
         session,
-        "uv pip install --system lamindb@git+https://github.com/laminlabs/lamindb[bionty]",
+        "uv pip install --system lamindb[bionty]@git+https://github.com/laminlabs/lamindb",
     )
     run_pytest(session, coverage=False)

--- a/noxfile.py
+++ b/noxfile.py
@@ -16,5 +16,4 @@ def test(session: nox.Session) -> None:
         session,
         "pip install lamindb_setup@git+https://github.com/laminlabs/lamindb-setup",
     )
-    login_testuser1(session)
     run_pytest(session, coverage=False)

--- a/noxfile.py
+++ b/noxfile.py
@@ -14,6 +14,6 @@ def test(session: nox.Session) -> None:
     run(session, "uv pip install --system -e .[dev]")
     run(
         session,
-        "uv pip install lamindb@git+https://github.com/laminlabs/lamindb",
+        "uv pip install --system lamindb@git+https://github.com/laminlabs/lamindb",
     )
     run_pytest(session, coverage=False)

--- a/noxfile.py
+++ b/noxfile.py
@@ -14,6 +14,6 @@ def test(session: nox.Session) -> None:
     run(session, "uv pip install --system -e .[dev]")
     run(
         session,
-        "uv pip install --system lamindb@git+https://github.com/laminlabs/lamindb",
+        "uv pip install --system lamindb@git+https://github.com/laminlabs/lamindb[bionty]",
     )
     run_pytest(session, coverage=False)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
 ]
 # mandate zero dependencies
 dependencies = [
@@ -44,7 +45,7 @@ omit = [
 [tool.ruff]
 src = ["src"]
 line-length = 88
-select = [
+lint.select = [
     "F",  # Errors detected by Pyflakes
     "E",  # Error detected by Pycodestyle
     "W",  # Warning detected by Pycodestyle
@@ -60,7 +61,7 @@ select = [
     "NPY",  # Numpy specific rules
     "PTH"  # Use pathlib
 ]
-ignore = [
+lint.ignore = [
     # Do not catch blind exception: `Exception`
     "BLE001",
     # Errors from function calls in argument defaults. These are fine when the result is immutable.
@@ -129,10 +130,10 @@ ignore = [
     "PTH123",
 ]
 
-[tool.ruff.pydocstyle]
+[tool.ruff.lint.pydocstyle]
 convention = "google"
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "docs/*" = ["I"]
 "tests/*" = ["D"]
 "*/__init__.py" = ["F401"]

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -9,9 +9,9 @@ def setup_bionty_instance():
     ln_setup.delete("test-bionty-db", force=True)
 
 
-def test_migrate_check(setup_instance):
+def test_migrate_check(setup_bionty_instance):
     assert ln_setup.migrate.check()
 
 
-def test_system_check(setup_instance):
+def test_system_check(setup_bionty_instance):
     ln_setup.django("check")

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -2,11 +2,11 @@ import lamindb_setup as ln_setup
 import pytest
 
 
-@pytest.fixture(scope="function")
-def setup_instance():
-    ln_setup.init(storage="./testdb")
+@pytest.fixture(scope="module")
+def setup_bionty_instance():
+    ln_setup.init(storage="./test-bionty-db", schema="bionty")
     yield
-    ln_setup.delete("testdb", force=True)
+    ln_setup.delete("test-bionty-db", force=True)
 
 
 def test_migrate_check(setup_instance):

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -2,7 +2,7 @@ import lamindb_setup as ln_setup
 import pytest
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def setup_instance():
     ln_setup.init(storage="./testdb")
     yield

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -7,9 +7,9 @@ import pytest
 
 @pytest.fixture(scope="module")
 def setup_bionty_instance():
-    ln.setup.init(storage="./testdb", schema="bionty")
+    ln.setup.init(storage="./test-bionty-db", schema="bionty")
     yield
-    ln.setup.delete("testdb", force=True)
+    ln.setup.delete("test-bionty-db", force=True)
 
 
 def _strip_ansi(text: str) -> str:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,14 +2,6 @@ import re
 import textwrap
 
 import lamindb as ln
-import pytest
-
-
-@pytest.fixture(scope="function")
-def setup_bionty_instance():
-    ln.setup.init(storage="./test-bionty-db", schema="bionty")
-    yield
-    ln.setup.delete("test-bionty-db", force=True)
 
 
 def _strip_ansi(text: str) -> str:
@@ -18,7 +10,7 @@ def _strip_ansi(text: str) -> str:
     return ansi_escape.sub("", text)
 
 
-def test_registry__repr__param(setup_bionty_instance):
+def test_registry__repr__param():
     param = ln.Param
     expected_repr = textwrap.dedent("""\
     Param
@@ -39,7 +31,7 @@ def test_registry__repr__param(setup_bionty_instance):
     assert actual_repr.strip() == expected_repr.strip()
 
 
-def test_registry__repr__artifact(setup_bionty_instance):
+def test_registry__repr__artifact():
     artifact = ln.Artifact
     expected_repr = textwrap.dedent("""\
     Artifact

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3,6 +3,8 @@ import textwrap
 
 import lamindb as ln
 
+# The tests defined in this script use the lamindb instance defined in test_integrity
+
 
 def _strip_ansi(text: str) -> str:
     """Remove ANSI escape sequences from a string."""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,6 +1,13 @@
+import re
 import textwrap
 
 import lamindb as ln
+
+
+def strip_ansi(text: str) -> str:
+    """Remove ANSI escape sequences from a string."""
+    ansi_escape = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
+    return ansi_escape.sub("", text)
 
 
 def test_registry__repr__param():
@@ -20,7 +27,8 @@ def test_registry__repr__param():
         .paramvalue: ParamValue
     """).strip()
 
-    assert repr(param) == expected_repr
+    actual_repr = strip_ansi(repr(param))
+    assert actual_repr.strip() == expected_repr.strip()
 
 
 def test_registry__repr__artifact():
@@ -84,4 +92,5 @@ def test_registry__repr__artifact():
         .reference_of_sources: bionty.Source
     """
 
-    assert repr(artifact) == expected_repr
+    actual_repr = strip_ansi(repr(artifact))
+    assert actual_repr.strip() == expected_repr.strip()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,84 @@
+import lamindb as ln
+
+
+def test_registry__repr__param():
+    param = ln.Param
+    repr_string = repr(param)
+
+    # Header
+    assert "Param" in repr_string
+
+    # Basic fields
+    assert ".id: BigAutoField" in repr_string
+    assert ".name: CharField" in repr_string
+    assert ".dtype: CharField" in repr_string
+    assert ".created_at: DateTimeField" in repr_string
+    assert ".updated_at: DateTimeField" in repr_string
+
+    # Relational fields
+    assert ".created_by: User" in repr_string
+    assert ".run: Run" in repr_string
+    assert ".previous_runs: Run" in repr_string
+    assert ".paramvalue: ParamValue" in repr_string
+
+
+def test_registry__repr__artifact():
+    artifact = ln.Artifact
+    repr_string = repr(artifact)
+
+    # Header
+    assert "Artifact" in repr_string
+
+    # Basic fields
+    assert ".id: AutoField" in repr_string
+    assert ".uid: CharField" in repr_string
+    assert ".description: CharField" in repr_string
+    assert ".key: CharField" in repr_string
+    assert ".suffix: CharField" in repr_string
+    assert ".type: CharField" in repr_string
+    assert ".accessor: CharField" in repr_string
+    assert ".size: BigIntegerField" in repr_string
+    assert ".hash: CharField" in repr_string
+    assert ".hash_type: CharField" in repr_string
+    assert ".n_objects: BigIntegerField" in repr_string
+    assert ".n_observations: BigIntegerField" in repr_string
+    assert ".visibility: SmallIntegerField" in repr_string
+    assert ".key_is_virtual: BooleanField" in repr_string
+    assert ".version: CharField" in repr_string
+    assert ".created_at: DateTimeField" in repr_string
+    assert ".updated_at: DateTimeField" in repr_string
+
+    # Relational fields
+    assert ".created_by: User" in repr_string
+    assert ".storage: Storage" in repr_string
+    assert ".transform: Transform" in repr_string
+    assert ".run: Run" in repr_string
+    assert ".ulabels: ULabel" in repr_string
+    assert ".input_of: Run" in repr_string
+    assert ".previous_runs: Run" in repr_string
+    assert ".feature_sets: FeatureSet" in repr_string
+    assert ".feature_values: FeatureValue" in repr_string
+    assert ".param_values: ParamValue" in repr_string
+    assert ".latest_report_of: Transform" in repr_string
+    assert ".source_code_of: Transform" in repr_string
+    assert ".report_of: Run" in repr_string
+    assert ".environment_of: Run" in repr_string
+    assert ".collection: Collection" in repr_string
+    assert ".collections: Collection" in repr_string
+
+    # Bionty fields
+    assert ".organisms: bionty.Organism" in repr_string
+    assert ".genes: bionty.Gene" in repr_string
+    assert ".proteins: bionty.Protein" in repr_string
+    assert ".cell_markers: bionty.CellMarker" in repr_string
+    assert ".tissues: bionty.Tissue" in repr_string
+    assert ".cell_types: bionty.CellType" in repr_string
+    assert ".diseases: bionty.Disease" in repr_string
+    assert ".cell_lines: bionty.CellLine" in repr_string
+    assert ".phenotypes: bionty.Phenotype" in repr_string
+    assert ".pathways: bionty.Pathway" in repr_string
+    assert ".experimental_factors: bionty.ExperimentalFactor" in repr_string
+    assert ".developmental_stages: bionty.DevelopmentalStage" in repr_string
+    assert ".ethnicities: bionty.Ethnicity" in repr_string
+    assert ".reference_of_source: bionty.Source" in repr_string
+    assert ".reference_of_sources: bionty.Source" in repr_string

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,84 +1,87 @@
+import textwrap
+
 import lamindb as ln
 
 
 def test_registry__repr__param():
     param = ln.Param
-    repr_string = repr(param)
+    expected_repr = textwrap.dedent("""\
+    Param
+      Basic fields
+        .id: BigAutoField
+        .name: CharField
+        .dtype: CharField
+        .created_at: DateTimeField
+        .updated_at: DateTimeField
+      Relational fields
+        .created_by: User
+        .run: Run
+        .previous_runs: Run
+        .paramvalue: ParamValue
+    """).strip()
 
-    # Header
-    assert "Param" in repr_string
-
-    # Basic fields
-    assert ".id: BigAutoField" in repr_string
-    assert ".name: CharField" in repr_string
-    assert ".dtype: CharField" in repr_string
-    assert ".created_at: DateTimeField" in repr_string
-    assert ".updated_at: DateTimeField" in repr_string
-
-    # Relational fields
-    assert ".created_by: User" in repr_string
-    assert ".run: Run" in repr_string
-    assert ".previous_runs: Run" in repr_string
-    assert ".paramvalue: ParamValue" in repr_string
+    assert repr(param) == expected_repr
 
 
 def test_registry__repr__artifact():
     artifact = ln.Artifact
-    repr_string = repr(artifact)
+    expected_repr = textwrap.dedent("""\
+    Artifact
+      Basic fields
+        .id: AutoField
+        .uid: CharField
+        .description: CharField
+        .key: CharField
+        .suffix: CharField
+        .type: CharField
+        .accessor: CharField
+        .size: BigIntegerField
+        .hash: CharField
+        .hash_type: CharField
+        .n_objects: BigIntegerField
+        .n_observations: BigIntegerField
+        .visibility: SmallIntegerField
+        .key_is_virtual: BooleanField
+        .version: CharField
+        .created_at: DateTimeField
+        .updated_at: DateTimeField
+      Relational fields
+        .created_by: User
+        .storage: Storage
+        .transform: Transform
+        .run: Run
+        .ulabels: ULabel
+        .input_of: Run
+        .previous_runs: Run
+        .feature_sets: FeatureSet
+        .feature_values: FeatureValue
+        .param_values: ParamValue
+        .latest_report_of: Transform
+        .source_code_of: Transform
+        .report_of: Run
+        .environment_of: Run
+        .collection: Collection
+        .collections: Collection
+    """).strip()
 
-    # Header
-    assert "Artifact" in repr_string
+    # TODO these fields should also be tested for but they require an instance with Bionty
+    """
+      Bionty fields
+        .organisms: bionty.Organism
+        .genes: bionty.Gene
+        .proteins: bionty.Protein
+        .cell_markers: bionty.CellMarker
+        .tissues: bionty.Tissue
+        .cell_types: bionty.CellType
+        .diseases: bionty.Disease
+        .cell_lines: bionty.CellLine
+        .phenotypes: bionty.Phenotype
+        .pathways: bionty.Pathway
+        .experimental_factors: bionty.ExperimentalFactor
+        .developmental_stages: bionty.DevelopmentalStage
+        .ethnicities: bionty.Ethnicity
+        .reference_of_source: bionty.Source
+        .reference_of_sources: bionty.Source
+    """
 
-    # Basic fields
-    assert ".id: AutoField" in repr_string
-    assert ".uid: CharField" in repr_string
-    assert ".description: CharField" in repr_string
-    assert ".key: CharField" in repr_string
-    assert ".suffix: CharField" in repr_string
-    assert ".type: CharField" in repr_string
-    assert ".accessor: CharField" in repr_string
-    assert ".size: BigIntegerField" in repr_string
-    assert ".hash: CharField" in repr_string
-    assert ".hash_type: CharField" in repr_string
-    assert ".n_objects: BigIntegerField" in repr_string
-    assert ".n_observations: BigIntegerField" in repr_string
-    assert ".visibility: SmallIntegerField" in repr_string
-    assert ".key_is_virtual: BooleanField" in repr_string
-    assert ".version: CharField" in repr_string
-    assert ".created_at: DateTimeField" in repr_string
-    assert ".updated_at: DateTimeField" in repr_string
-
-    # Relational fields
-    assert ".created_by: User" in repr_string
-    assert ".storage: Storage" in repr_string
-    assert ".transform: Transform" in repr_string
-    assert ".run: Run" in repr_string
-    assert ".ulabels: ULabel" in repr_string
-    assert ".input_of: Run" in repr_string
-    assert ".previous_runs: Run" in repr_string
-    assert ".feature_sets: FeatureSet" in repr_string
-    assert ".feature_values: FeatureValue" in repr_string
-    assert ".param_values: ParamValue" in repr_string
-    assert ".latest_report_of: Transform" in repr_string
-    assert ".source_code_of: Transform" in repr_string
-    assert ".report_of: Run" in repr_string
-    assert ".environment_of: Run" in repr_string
-    assert ".collection: Collection" in repr_string
-    assert ".collections: Collection" in repr_string
-
-    # Bionty fields
-    assert ".organisms: bionty.Organism" in repr_string
-    assert ".genes: bionty.Gene" in repr_string
-    assert ".proteins: bionty.Protein" in repr_string
-    assert ".cell_markers: bionty.CellMarker" in repr_string
-    assert ".tissues: bionty.Tissue" in repr_string
-    assert ".cell_types: bionty.CellType" in repr_string
-    assert ".diseases: bionty.Disease" in repr_string
-    assert ".cell_lines: bionty.CellLine" in repr_string
-    assert ".phenotypes: bionty.Phenotype" in repr_string
-    assert ".pathways: bionty.Pathway" in repr_string
-    assert ".experimental_factors: bionty.ExperimentalFactor" in repr_string
-    assert ".developmental_stages: bionty.DevelopmentalStage" in repr_string
-    assert ".ethnicities: bionty.Ethnicity" in repr_string
-    assert ".reference_of_source: bionty.Source" in repr_string
-    assert ".reference_of_sources: bionty.Source" in repr_string
+    assert repr(artifact) == expected_repr

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -6,19 +6,19 @@ import pytest
 
 
 @pytest.fixture(scope="module")
-def setup_instance():
+def setup_bionty_instance():
     ln.setup.init(storage="./testdb", schema="bionty")
     yield
     ln.setup.delete("testdb", force=True)
 
 
-def strip_ansi(text: str) -> str:
+def _strip_ansi(text: str) -> str:
     """Remove ANSI escape sequences from a string."""
     ansi_escape = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
     return ansi_escape.sub("", text)
 
 
-def test_registry__repr__param(setup_instance):
+def test_registry__repr__param(setup_bionty_instance):
     param = ln.Param
     expected_repr = textwrap.dedent("""\
     Param
@@ -35,11 +35,11 @@ def test_registry__repr__param(setup_instance):
         .paramvalue: ParamValue
     """).strip()
 
-    actual_repr = strip_ansi(repr(param))
+    actual_repr = _strip_ansi(repr(param))
     assert actual_repr.strip() == expected_repr.strip()
 
 
-def test_registry__repr__artifact(setup_instance):
+def test_registry__repr__artifact(setup_bionty_instance):
     artifact = ln.Artifact
     expected_repr = textwrap.dedent("""\
     Artifact
@@ -96,5 +96,5 @@ def test_registry__repr__artifact(setup_instance):
         .reference_of_sources: bionty.Source
     """).strip()
 
-    actual_repr = strip_ansi(repr(artifact))
+    actual_repr = _strip_ansi(repr(artifact))
     assert actual_repr.strip() == expected_repr.strip()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,6 +2,14 @@ import re
 import textwrap
 
 import lamindb as ln
+import pytest
+
+
+@pytest.fixture(scope="module")
+def setup_instance():
+    ln.setup.init(storage="./testdb", schema="bionty")
+    yield
+    ln.setup.delete("testdb", force=True)
 
 
 def strip_ansi(text: str) -> str:
@@ -10,7 +18,7 @@ def strip_ansi(text: str) -> str:
     return ansi_escape.sub("", text)
 
 
-def test_registry__repr__param():
+def test_registry__repr__param(setup_instance):
     param = ln.Param
     expected_repr = textwrap.dedent("""\
     Param
@@ -31,7 +39,7 @@ def test_registry__repr__param():
     assert actual_repr.strip() == expected_repr.strip()
 
 
-def test_registry__repr__artifact():
+def test_registry__repr__artifact(setup_instance):
     artifact = ln.Artifact
     expected_repr = textwrap.dedent("""\
     Artifact
@@ -70,10 +78,6 @@ def test_registry__repr__artifact():
         .environment_of: Run
         .collection: Collection
         .collections: Collection
-    """).strip()
-
-    # TODO these fields should also be tested for but they require an instance with Bionty
-    """
       Bionty fields
         .organisms: bionty.Organism
         .genes: bionty.Gene
@@ -90,7 +94,7 @@ def test_registry__repr__artifact():
         .ethnicities: bionty.Ethnicity
         .reference_of_source: bionty.Source
         .reference_of_sources: bionty.Source
-    """
+    """).strip()
 
     actual_repr = strip_ansi(repr(artifact))
     assert actual_repr.strip() == expected_repr.strip()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -5,7 +5,7 @@ import lamindb as ln
 import pytest
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def setup_bionty_instance():
     ln.setup.init(storage="./test-bionty-db", schema="bionty")
     yield


### PR DESCRIPTION
Fixes https://github.com/laminlabs/lnschema-core/issues/404
Fixes https://github.com/laminlabs/lnschema-core/issues/406

1. Simplify `__repr__` by removing code that was not needed anymore.
2. Add a test for `__repr__`. Side effect: We now install `lamindb[bionty]` also in the CI.