### PR TITLE
✨Add source to validate and Improve docstrings

### DIFF
--- a/lnschema_core/models.py
+++ b/lnschema_core/models.py
@@ -228,14 +228,13 @@ class CanValidate:
         Being mappable means that an exact match exists.
 
         Args:
-            values: Values that will be checked against the
-                field.
+            values: Values that will be checked against the field.
             field: The field of values. Examples are `'ontology_id'` to map
                 against the source ID or `'name'` to map against the ontologies
                 field names.
-            mute: Mute logging.
+            mute: Whether to mute logging.
             organism: An Organism name or record.
-            source: A Source record.
+            source: A Source record that specifies the version to inspect against.
 
         See Also:
             :meth:`~lamindb.core.CanValidate.validate`
@@ -261,6 +260,7 @@ class CanValidate:
         *,
         mute: bool = False,
         organism: str | Record | None = None,
+        source: Record | None = None,
     ) -> np.ndarray:
         """Validate values against existing values of a string field.
 
@@ -271,7 +271,9 @@ class CanValidate:
             field: The field of values.
                     Examples are `'ontology_id'` to map against the source ID
                     or `'name'` to map against the ontologies field names.
-            mute: Mute logging.
+            mute: Whether to mute logging.
+            organism: An Organism name or record.
+            source: A Source record that specifies the version to validate against.
 
         Returns:
             A vector of booleans indicating if an element is validated.
@@ -314,7 +316,7 @@ class CanValidate:
             return_field: The field to return. Defaults to field.
             return_mapper: If `True`, returns `{input_value: standardized_name}`.
             case_sensitive: Whether the mapping is case sensitive.
-            mute: Mute logging.
+            mute: Whether to mute logging.
             public_aware: Whether to standardize from Bionty reference. Defaults to `True` for Bionty registries.
             keep: When a synonym maps to multiple names, determines which duplicates to mark as `pd.DataFrame.duplicated`:
                     - `"first"`: returns the first mapped standardized name
@@ -358,9 +360,9 @@ class CanValidate:
         """Add synonyms to a record.
 
         Args:
-            synonym
-            force
-            save
+            synonym: The synonyms to add to the record.
+            force: Whether to add synonyms even if they are already synonyms of other records.
+            save: Whether to save the record to the database.
 
         See Also:
             :meth:`~lamindb.core.CanValidate.remove_synonym`
@@ -383,7 +385,7 @@ class CanValidate:
         """Remove synonyms from a record.
 
         Args:
-            synonym: The synonym value.
+            synonym: The synonym values to remove.
 
         See Also:
             :meth:`~lamindb.core.CanValidate.add_synonym`
@@ -442,7 +444,7 @@ class HasParents:
 
         Args:
             field: Field to display on graph
-            with_children: Also show children.
+            with_children: Whether to also show children.
             distance: Maximum distance still shown.
 
         Ontological hierarchies: :class:`~lamindb.ULabel` (project & sub-project), :class:`~bionty.CellType` (cell type & subtype).
@@ -679,10 +681,10 @@ class RecordMeta(ModelBase):
             create: Whether to create records if they don't exist.
             organism: A `bionty.Organism` name or record.
             source: A `bionty.Source` record.
-            mute: Do not show logging.
+            mute: Whether to mute logging.
 
         Returns:
-            A list of validated records. For bionty registries. lso returns knowledge-coupled records.
+            A list of validated records. For bionty registries. Also returns knowledge-coupled records.
 
         Notes:
             For more info, see tutorial: :doc:`bio-registries`.
@@ -763,7 +765,7 @@ class RecordMeta(ModelBase):
         """Get a single record.
 
         Args:
-            idlike: Either a uid stub.  uid or an integer id.
+            idlike: Either a uid stub, uid or an integer id.
 
         Returns:
             A record.
@@ -928,8 +930,7 @@ class HasFeatures:
     features: FeatureManager = FeatureManager  # type: ignore
     """Feature manager.
 
-    Features denote dataset dimensions, i.e., the variables that measure labels
-    & numbers.
+    Features denote dataset dimensions, i.e., the variables that measure labels & numbers.
 
     Annotate with features & values::
 
@@ -949,7 +950,6 @@ class HasFeatures:
     `DataFrame`-like artifact and annotates it with features corresponding to
     these columns. `artifact.features.add_values`, by contrast, does not
     validate the content of the artifact.
-
     """
 
     @property

--- a/lnschema_core/models.py
+++ b/lnschema_core/models.py
@@ -307,6 +307,7 @@ class CanValidate:
         keep: Literal["first", "last", False] = "first",
         synonyms_field: str = "synonyms",
         organism: str | Record | None = None,
+        source: Record | None = None,
     ) -> list[str] | dict[str, str]:
         """Maps input synonyms to standardized names.
 
@@ -328,6 +329,7 @@ class CanValidate:
                   When a field is converted into return_field, keep marks which matches to keep when multiple return_field values map to the same field value.
             synonyms_field: A field containing the concatenated synonyms.
             organism: An Organism name or record.
+            source: A Source record that specifies the version to validate against.
 
         Returns:
             If `return_mapper` is `False`: a list of standardized names. Otherwise,

--- a/lnschema_core/models.py
+++ b/lnschema_core/models.py
@@ -234,7 +234,7 @@ class CanValidate:
                 field names.
             mute: Whether to mute logging.
             organism: An Organism name or record.
-            source: A Source record that specifies the version to inspect against.
+            source: A `bionty.Source` record that specifies the version to inspect against.
 
         See Also:
             :meth:`~lamindb.core.CanValidate.validate`
@@ -273,7 +273,7 @@ class CanValidate:
                     or `'name'` to map against the ontologies field names.
             mute: Whether to mute logging.
             organism: An Organism name or record.
-            source: A Source record that specifies the version to validate against.
+            source: A `bionty.Source` record that specifies the version to validate against.
 
         Returns:
             A vector of booleans indicating if an element is validated.
@@ -329,7 +329,7 @@ class CanValidate:
                   When a field is converted into return_field, keep marks which matches to keep when multiple return_field values map to the same field value.
             synonyms_field: A field containing the concatenated synonyms.
             organism: An Organism name or record.
-            source: A Source record that specifies the version to validate against.
+            source: A `bionty.Source` record that specifies the version to validate against.
 
         Returns:
             If `return_mapper` is `False`: a list of standardized names. Otherwise,
@@ -682,7 +682,7 @@ class RecordMeta(ModelBase):
             field: A `Record` field to look up, e.g., `bt.CellMarker.name`.
             create: Whether to create records if they don't exist.
             organism: A `bionty.Organism` name or record.
-            source: A `bionty.Source` record.
+            source: A `bionty.Source` record to validate against to create records for.
             mute: Whether to mute logging.
 
         Returns:


### PR DESCRIPTION
A part of https://github.com/laminlabs/lamindb/issues/1778

1. Adds `source` to the interface of `validate` and `standardize`.
2. Fixes a few docstrings.