### PR TITLE
🐛Fix UserDoesNotExist

### DIFF
--- a/lnschema_core/users.py
+++ b/lnschema_core/users.py
@@ -12,9 +12,12 @@ def current_user_id() -> int:
         if ln_setup.core.django.IS_MIGRATING:
             return 1
         else:
+            exc_attr = (
+                "DoesNotExist" if hasattr(User, "DoesNotExist") else "_DoesNotExist"
+            )
             try:
                 user_id = User.objects.get(uid=settings.user.uid).id
-            except User._DoesNotExist:
+            except getattr(User, exc_attr):
                 register_user(settings.user)
                 user_id = User.objects.get(uid=settings.user.uid).id
             return user_id

--- a/lnschema_core/users.py
+++ b/lnschema_core/users.py
@@ -14,7 +14,7 @@ def current_user_id() -> int:
         else:
             try:
                 user_id = User.objects.get(uid=settings.user.uid).id
-            except User.DoesNotExist:
+            except User._DoesNotExist:
                 register_user(settings.user)
                 user_id = User.objects.get(uid=settings.user.uid).id
             return user_id


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/zeth/miniconda3/envs/lamindb/lib/python3.11/site-packages/django/db/models/base.py", line 517, in __init__
    rel_obj = kwargs.pop(field.name)
              ^^^^^^^^^^^^^^^^^^^^^^
KeyError: 'created_by'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/zeth/miniconda3/envs/lamindb/lib/python3.11/site-packages/django/db/models/base.py", line 522, in __init__
    val = kwargs.pop(field.attname)
          ^^^^^^^^^^^^^^^^^^^^^^^^^
KeyError: 'created_by_id'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/zeth/PycharmProjects/lamindb/sub/lnschema-core/lnschema_core/users.py", line 16, in query_user_id
    user_id = User.objects.get(uid=settings.user.uid).id
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zeth/miniconda3/envs/lamindb/lib/python3.11/site-packages/django/db/models/manager.py", line 87, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zeth/miniconda3/envs/lamindb/lib/python3.11/site-packages/django/db/models/query.py", line 649, in get
    raise self.model._DoesNotExist(
lnschema_core.models.User._DoesNotExist: User matching query does not exist.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/zeth/PycharmProjects/bionty/bionty/core/_bionty.py", line 47, in sync_all_sources_to_latest
    record = Source(**kwargs)
             ^^^^^^^^^^^^^^^^
  File "/home/zeth/PycharmProjects/bionty/bionty/models.py", line 1451, in __init__
    super().__init__(*args, **kwargs)
  File "/home/zeth/PycharmProjects/lamindb/lamindb/_record.py", line 107, in __init__
    super(Record, record).__init__(**kwargs)
  File "/home/zeth/PycharmProjects/lamindb/sub/lnschema-core/lnschema_core/models.py", line 186, in __init__
    super().__init__(*args, **kwargs)
  File "/home/zeth/PycharmProjects/lamindb/sub/lnschema-core/lnschema_core/models.py", line 216, in __init__
    super().__init__(*args, **kwargs)
  File "/home/zeth/miniconda3/envs/lamindb/lib/python3.11/site-packages/django/db/models/base.py", line 524, in __init__
    val = field.get_default()
          ^^^^^^^^^^^^^^^^^^^
  File "/home/zeth/miniconda3/envs/lamindb/lib/python3.11/site-packages/django/db/models/fields/related.py", line 1134, in get_default
    field_default = super().get_default()
                    ^^^^^^^^^^^^^^^^^^^^^
  File "/home/zeth/miniconda3/envs/lamindb/lib/python3.11/site-packages/django/db/models/fields/__init__.py", line 1021, in get_default
    return self._get_default()
           ^^^^^^^^^^^^^^^^^^^
  File "/home/zeth/PycharmProjects/lamindb/sub/lnschema-core/lnschema_core/users.py", line 24, in current_user_id
    user_id_cache[settings.instance.slug] = query_user_id()
                                            ^^^^^^^^^^^^^^^
  File "/home/zeth/PycharmProjects/lamindb/sub/lnschema-core/lnschema_core/users.py", line 17, in query_user_id
    except User.DoesNotExist:
           ^^^^^^^^^^^^^^^^^
AttributeError: type object 'User' has no attribute 'DoesNotExist'. Did you mean: '_DoesNotExist'?
```

It does resolve to a Django attribute through vscode but doesn't seem to work. It's fixed through this. Not sure why no one has run into this yet?