### PR TITLE
🎨 Ignore `ManyToOneRel` in `get_relational_fields`

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -22,7 +22,6 @@ def test_registry__repr__param(setup_instance):
       Relational fields
         .created_by: User
         .run: Run
-        .paramvalue: ParamValue
     """).strip()
 
     actual_repr = _strip_ansi(repr(param))


### PR DESCRIPTION
User is a foreign key on almost all entities. For any given user, I might find it convenient to query all artifacts that the user ingested via: `user.artifact_set.all()`

However, I have a hard time imagining a query that looks like so because the result is always going to be exactly one user; the user that’s directly available as `artifact.created_by`
```
ln.User.filter(artifact=artifact).all()
```

Sometimes, I might only have the uid of an artifact. In that case, I can either query the user table or the artifact table directly. Querying the user table will be slightly faster.
```
ln.User.get(artifact__uid=artifact_uid)
```

The clutter produced by accounting for these backward references is enormous. For instance, on `User`:
<img width="1551" alt="image" src="https://github.com/user-attachments/assets/3707b5dd-7ff9-4c8a-b9b1-585193b294ee">

I conclude that the minimal benefits in convenience for writing queries of the form `user.artifact_set.all()` do not justify the clutter in the API.

This present PR is making a change that hides these backward relationships (`ManyToOneRel`).

A second PR will create a migration that prevents Django from dynamically generating these attributes.

Internal [reference](https://laminlabs.slack.com/archives/C046F63LJJ2/p1725833297001919).