### PR TITLE
✨ Add missing Django model field subclasses with default `blank=True`.

### DIFF
--- a/lnschema_core/fields.py
+++ b/lnschema_core/fields.py
@@ -146,3 +146,135 @@ class DurationField(models.DurationField):
     def __init__(self, *args, **kwargs):
         kwargs.setdefault("blank", True)
         super().__init__(*args, **kwargs)
+
+
+class URLField(models.URLField):
+    """Custom `URLField` with default values for `blank`.
+
+    Django default values for `URLField` are `blank=False`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault("blank", True)
+        super().__init__(*args, **kwargs)
+
+
+class EmailField(models.EmailField):
+    """Custom `EmailField` with default values for `blank`.
+
+    Django default values for `EmailField` are `blank=False`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault("blank", True)
+        super().__init__(*args, **kwargs)
+
+
+class TimeField(models.TimeField):
+    """Custom `TimeField` with default values for `blank`.
+
+    Django default values for `TimeField` are `blank=False`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault("blank", True)
+        super().__init__(*args, **kwargs)
+
+
+class SlugField(models.SlugField):
+    """Custom `SlugField` with default values for `blank`.
+
+    Django default values for `SlugField` are `blank=False`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault("blank", True)
+        super().__init__(*args, **kwargs)
+
+
+class UUIDField(models.UUIDField):
+    """Custom `UUIDField` with default values for `blank`.
+
+    Django default values for `UUIDField` are `blank=False`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault("blank", True)
+        super().__init__(*args, **kwargs)
+
+
+class PositiveIntegerField(models.PositiveIntegerField):
+    """Custom `PositiveIntegerField` with default values for `blank`.
+
+    Django default values for `PositiveIntegerField` are `blank=False`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault("blank", True)
+        super().__init__(*args, **kwargs)
+
+
+class PositiveSmallIntegerField(models.PositiveSmallIntegerField):
+    """Custom `PositiveSmallIntegerField` with default values for `blank`.
+
+    Django default values for `PositiveSmallIntegerField` are `blank=False`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault("blank", True)
+        super().__init__(*args, **kwargs)
+
+
+class SmallIntegerField(models.SmallIntegerField):
+    """Custom `SmallIntegerField` with default values for `blank`.
+
+    Django default values for `SmallIntegerField` are `blank=False`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault("blank", True)
+        super().__init__(*args, **kwargs)
+
+
+class BinaryField(models.BinaryField):
+    """Custom `BinaryField` with default values for `blank`.
+
+    Django default values for `BinaryField` are `blank=False`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault("blank", True)
+        super().__init__(*args, **kwargs)
+
+
+class GenericIPAddressField(models.GenericIPAddressField):
+    """Custom `GenericIPAddressField` with default values for `blank`.
+
+    Django default values for `GenericIPAddressField` are `blank=False`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault("blank", True)
+        super().__init__(*args, **kwargs)
+
+
+class FileField(models.FileField):
+    """Custom `FileField` with default values for `blank`.
+
+    Django default values for `FileField` are `blank=False`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault("blank", True)
+        super().__init__(*args, **kwargs)
+
+
+class ImageField(models.ImageField):
+    """Custom `ImageField` with default values for `blank`.
+
+    Django default values for `ImageField` are `blank=False`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault("blank", True)
+        super().__init__(*args, **kwargs)


### PR DESCRIPTION
Required for `findrefs` where I have a URLField.

Extends our custom field collection by adding commonly used Django model fields (URL, Email, Time, Slug, UUID, etc.) following the same pattern of setting blank=True by default. This completes our set of field overrides to maintain  consistent behavior across all model field types.

Added fields:
- URLField
- EmailField
- TimeField
- SlugField
- UUIDField
- PositiveIntegerField
- PositiveSmallIntegerField
- SmallIntegerField
- BinaryField
- GenericIPAddressField
- FileField
- ImageField